### PR TITLE
Fix compilation error and unhandled Serial input error code

### DIFF
--- a/firmware/src/cli.c
+++ b/firmware/src/cli.c
@@ -176,7 +176,7 @@ void cli_run()
     }
 
     int c = getchar_timeout_us(0);
-    if (c == EOF) {
+    if (c < 0) {
         return;
     }
     if (c == 0) {


### PR DESCRIPTION
Does it occur to you guys that CLI console always spits out "Unknown command" every time you clicked Enter? Here's a patch for it (at least works well for me).